### PR TITLE
Koi worker offline exception

### DIFF
--- a/koi-worker.py
+++ b/koi-worker.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         "-t",
         "--sleep-retry",
         type=int,
-        default=10,
+        default=60,
         help="Number of seconds to wait before a retry",
     )
 
@@ -143,7 +143,6 @@ if __name__ == "__main__":
 
     # intialize retry counter
     retries = opt.retries
-    sleep_time = opt.sleep_time
 
     # connect using the credentials
     logging.info("connecting to %s", opt.server)
@@ -236,8 +235,8 @@ if __name__ == "__main__":
                 raise ex
 
             retries -= 1
-            logging.error("koi api is offline, retrying in %d seconds", sleep_time)
-            sleep(sleep_time)
+            logging.error("koi api is offline, retrying in %d seconds", opt.sleep_retry)
+            sleep(opt.sleep_retry)
 
             # set the online flag an try to athenticate
             pool.api.reconnect()

--- a/koi-worker.py
+++ b/koi-worker.py
@@ -22,13 +22,14 @@ import signal
 import sys
 import multiprocessing
 import koi_core as koi
+from koi_core.exceptions import KoiApiOfflineException
 from time import sleep
 
 signal_interrupt = False
 
 
 def sigint_handling(signum, frame):
-    # provide the user with some guidline about gracefully exiting the server
+    # provide the user with some guidline about gracefully exiting the worker
     global signal_interrupt
     if signal_interrupt:
         print(
@@ -41,7 +42,7 @@ def sigint_handling(signum, frame):
         signal_interrupt = True
         print(
             colorama.Fore.RED
-            + "\nThe server will gracefully terminate on the next opportunity. "
+            + "\nThe worker will gracefully terminate on the next opportunity. "
             "If a training is in progress this can, however, take a bit longer :( "
             "So if you really want to quit press CTRC-C again. "
             "But we will loose all unsaved progress then :'(. "
@@ -101,7 +102,21 @@ if __name__ == "__main__":
         "--start-method",
         type=str,
         default="NONE",
-        help="The startmethod used for multiprocessing",
+        help="The startmethod used for multiprocessing. [spawn, fork, NONE]",
+    )
+    p.add(
+        "-r",
+        "--retries",
+        type=int,
+        default=3,
+        help="The number of retries to make before giving up. A negative number will make it retry indefinitly",
+    )
+    p.add(
+        "-t",
+        "--sleep-retry",
+        type=int,
+        default=10,
+        help="Number of seconds to wait before a retry",
     )
 
     opt = p.parse_args()
@@ -126,84 +141,107 @@ if __name__ == "__main__":
     # initialize the koi_core
     koi.init()
 
+    # intialize retry counter
+    retries = opt.retries
+    sleep_time = opt.sleep_time
+
     # connect using the credentials
     logging.info("connecting to %s", opt.server)
     pool = koi.create_api_object_pool(opt.server, opt.user, opt.password)
 
     while 1:
-        # gracefully exit if needed
-        if signal_interrupt:
-            break
-
-        # iterate through all models
-        models = pool.get_all_models()
-        for model in models:
+        try:
             # gracefully exit if needed
             if signal_interrupt:
                 break
 
-            # if a filter is set and it does not match -> continue
-            if opt.model is not None and opt.model != model.name:
-                logging.debug(
-                    "skipping model %s as it does not match the filter %s",
-                    model.name,
-                    opt.model,
-                )
-                continue
-
-            # skip unfinalized models
-            if not model.finalized:
-                logging.debug("skipping model %s as it is not finalized", model.name)
-                continue
-
-            # iterate through all instances
-            instances = model.instances
-            for instance in instances:
+            # iterate through all models
+            models = pool.get_all_models()
+            for model in models:
                 # gracefully exit if needed
                 if signal_interrupt:
                     break
 
                 # if a filter is set and it does not match -> continue
-                if opt.instance is not None and opt.instance != instance.name:
+                if opt.model is not None and opt.model != model.name:
                     logging.debug(
-                        "skipping instance %s/%s as it does not match the filter %s",
+                        "skipping model %s as it does not match the filter %s",
                         model.name,
-                        instance.name,
-                        opt.instance,
+                        opt.model,
                     )
                     continue
 
-                # skip unfinalized instances
-                if not instance.finalized:
-                    logging.debug(
-                        "skipping instance %s/%s as it is not finalized",
-                        model.name,
-                        instance.name,
-                    )
+                # skip unfinalized models
+                if not model.finalized:
+                    logging.debug("skipping model %s as it is not finalized", model.name)
                     continue
 
-                # train the instance if its ready to train or the user forces it
-                if opt.force or instance.could_train:
-                    try:
-                        logging.info(
-                            "start to train instance %s/%s", model.name, instance.name
-                        )
-                        koi.control.train(instance, None, False)
-                    except Exception:
-                        logging.exception(
-                            "instance %s/%s had an exception", model.name, instance.name
-                        )
-                        raise
+                # iterate through all instances
+                instances = model.instances
+                for instance in instances:
+                    # gracefully exit if needed
+                    if signal_interrupt:
+                        break
 
-        # break here if the user selected to run once
-        if opt.once:
-            break
+                    # if a filter is set and it does not match -> continue
+                    if opt.instance is not None and opt.instance != instance.name:
+                        logging.debug(
+                            "skipping instance %s/%s as it does not match the filter %s",
+                            model.name,
+                            instance.name,
+                            opt.instance,
+                        )
+                        continue
 
-        logging.debug("sleeping for %d seconds", opt.sleep)
-        for _ in range(opt.sleep):
-            # gracefully exit if needed
-            if signal_interrupt:
+                    # skip unfinalized instances
+                    if not instance.finalized:
+                        logging.debug(
+                            "skipping instance %s/%s as it is not finalized",
+                            model.name,
+                            instance.name,
+                        )
+                        continue
+
+                    # train the instance if its ready to train or the user forces it
+                    if opt.force or instance.could_train:
+                        try:
+                            logging.info(
+                                "start to train instance %s/%s", model.name, instance.name
+                            )
+                            koi.control.train(instance, None, False)
+                        except KoiApiOfflineException as ex:
+                            raise ex
+                        except Exception:
+                            logging.exception(
+                                "instance %s/%s had an exception", model.name, instance.name
+                            )
+
+            # break here if the user selected to run once
+            if opt.once:
                 break
-            sleep(1)
+
+            # reset the retry counter
+            retries = opt.retries
+
+            logging.debug("sleeping for %d seconds", opt.sleep)
+            for _ in range(opt.sleep):
+                # gracefully exit if needed
+                if signal_interrupt:
+                    break
+                sleep(1)
+        except KoiApiOfflineException as ex:
+            if retries == 0:
+                # if the retry counter is initilizes with a negative value, we will try forever
+                logging.error("koi api is offline, giving up")
+                raise ex
+
+            retries -= 1
+            logging.error("koi api is offline, retrying in %d seconds", sleep_time)
+            sleep(sleep_time)
+
+            # set the online flag an try to athenticate
+            pool.api.reconnect()
+            continue
 
     logging.info("stopped")
+    sys.exit(0)

--- a/koi_core/api/__init__.py
+++ b/koi_core/api/__init__.py
@@ -12,10 +12,8 @@
 # Lesser General Public License for more details. A copy of the
 # GNU Lesser General Public License is distributed along with this
 # software and can be found at http://www.gnu.org/licenses/lgpl.html
-from koi_core.api.common import BaseAPI, RequestsAPI
-import requests
-from multiprocessing import Lock
 
+from koi_core.api.common import BaseAPI, RequestsAPI
 from .model import APIModels
 from .instance import APIInstances
 from .sample import APISamples
@@ -28,6 +26,7 @@ class API(RequestsAPI):
         self.models = APIModels(self)
         self.instances = APIInstances(self)
         self.samples = APISamples(self)
+
 
 class OfflineAPI(BaseAPI):
     def __init__(self):

--- a/koi_core/api/common.py
+++ b/koi_core/api/common.py
@@ -146,11 +146,15 @@ def _encode(object, cls, mapping):
 
 
 class BaseAPI:
-    """This class will always raise a KoiOfflineException. I.e. this class will respond like a normal API which is always offline"""
+    """This class will always raise a KoiOfflineException. I.e. this class will respond
+    like a normal API which is always offline"""
 
     def __init__(self):
         self._base_url = "offline://"
         self.online = False
+
+    def reconnect(self):
+        raise KoiApiOfflineException()
 
     def authenticate(self):
         raise KoiApiOfflineException()
@@ -227,6 +231,11 @@ class RequestsAPI(BaseAPI):
         self._password = password
         self._session = requests.Session()
         self.online = True
+
+    def reconnect(self):
+        if not self.online:
+            self.online = True
+            self.authenticate()
 
     def authenticate(self):
         if not self.online:

--- a/koi_core/resources/instance.py
+++ b/koi_core/resources/instance.py
@@ -218,7 +218,6 @@ class InstanceProxy(Instance):
 
     @property
     @cache
-    @offlineFeature
     def training_data(self, meta) -> bytes:
         t_dat = None
         new_meta = None
@@ -235,6 +234,7 @@ class InstanceProxy(Instance):
 
     @property
     @cache
+    @offlineFeature
     def inference_data(self, meta) -> bytes:
         i_dat = None
         new_meta = None


### PR DESCRIPTION
We want the koi-worker to be able to reconnect after the koi-core is switched into offline mode.
This is valuable when the service part is not responding in time due to the massive workload when both are run on the same machine.