### PR TITLE
Multiple instances

### DIFF
--- a/koi_core/__init__.py
+++ b/koi_core/__init__.py
@@ -46,6 +46,7 @@ def deinit():
             "KOI Core must be initialized before deinitialization"
         )
     getCachingPersistence().persistify()
+    koi_core.control.terminate()
     _isInitialized = False
 
 

--- a/koi_core/control/control.py
+++ b/koi_core/control/control.py
@@ -13,42 +13,64 @@
 # GNU Lesser General Public License is distributed along with this
 # software and can be found at http://www.gnu.org/licenses/lgpl.html
 
-from typing import Any, List
+from typing import Any, Dict, List
 from tempfile import TemporaryDirectory
 from koi_core.control import actions
 from koi_core.resources.instance import Instance
 from .runable_instance import RunableInstance
+from time import time
+
 
 _runable_instance: RunableInstance = None
+_active_instances: Dict[Instance, List] = {}
 
 
-def _set_instance(instance: Instance):
+def _set_instance(instance: Instance, max_instances: int = 1):
     global _runable_instance
-    if _runable_instance is not None:
-        if _runable_instance.instance == instance:
-            # instance is already avaiable as runable_instance - return
-            return
+    global _active_instances
 
-    # we need to load another instance:
-    if _runable_instance is not None:
-        _runable_instance.terminate()
-        _runable_instance = None
+    if _runable_instance is not None and _runable_instance.instance == instance:
+        # instance is already avaiable as runable_instance - return
+        return
 
-    _runable_instance = RunableInstance(instance)
+    if max_instances > 0 and len(_active_instances) > max_instances:
+        # we have too many instances...
+        sorted_instances = sorted(_active_instances.items(), key=lambda x: x[1][1], reverse=True)
+        sorted_instances = sorted_instances[-(len(sorted_instances)-max_instances):]
+
+        # remove the unused instances
+        for elem in sorted_instances:
+            elem[1][0].terminate()
+            del _active_instances[elem[0]]
+
+    if instance in _active_instances and _active_instances[instance][0].is_alive():
+        _runable_instance = _active_instances[instance][0]
+        _active_instances[instance][1] = time()
+        return
+    else:
+        # replace the oldest instance if the number is exhausted
+        if max_instances > 0 and len(_active_instances) == max_instances:
+            elem = sorted(_active_instances.items(), key=lambda x: x[1][1], reverse=True)[-1]
+            elem[1][0].terminate()
+            del _active_instances[elem[0]]
+
+        # create a new runable instance and add it to the dictionary
+        _runable_instance = RunableInstance(instance)
+        _active_instances[instance] = [_runable_instance, time()]
 
 
-def train(instance: Instance, batch_iterable=None, dev=False):
+def train(instance: Instance, batch_iterable=None, dev=False, max_instances=1):
     if dev:
         temp_dir = TemporaryDirectory()
         model = instance.load_code(temp_dir.name)
         actions.train(model, instance, batch_iterable)
         temp_dir.cleanup()
     else:
-        _set_instance(instance)
+        _set_instance(instance, max_instances)
         _runable_instance.train(batch_iterable)
 
 
-def infer(instance: Instance, data, dev=False, model=None) -> List[Any]:
+def infer(instance: Instance, data, dev=False, model=None, max_instances=1) -> List[Any]:
     if dev:
         temp_dir = None
 
@@ -63,10 +85,10 @@ def infer(instance: Instance, data, dev=False, model=None) -> List[Any]:
         return ret
 
     else:
-        _set_instance(instance)
+        _set_instance(instance, max_instances)
         return _runable_instance.infer(data)
 
 
 def terminate():
-    if _runable_instance is not None:
-        _runable_instance.terminate()
+    for elem in _active_instances.values():
+        elem[0].terminate()

--- a/koi_core/control/runable_instance.py
+++ b/koi_core/control/runable_instance.py
@@ -126,9 +126,12 @@ class RunableInstance():
         self._pipe.send(_ExitCommand())
 
         # wait for the process to finish
-        self._process.join(0.5)
+        self._process.join(3.0)
 
         # check the processes exit code
         if self._process.exitcode is not None:
             # kill if necessary
             self._process.terminate()
+
+    def is_alive(self):
+        return self._process.is_alive()

--- a/koi_core/resources/instance.py
+++ b/koi_core/resources/instance.py
@@ -25,14 +25,6 @@ if TYPE_CHECKING:
     from koi_core.resources.pool import LocalOnlyObjectPool, APIObjectPool
 
 
-def _consumed_filter(s: Sample):
-    return s.consumed and not s.obsolete
-
-
-def _unconsumed_filter(s: Sample):
-    return not s.consumed and not s.obsolete
-
-
 class Descriptor:
     id: DescriptorId
     key: str
@@ -100,6 +92,7 @@ class DescriptorProxy(Descriptor):
 
 
 class Instance:
+    id: Union[InstanceId, ModelId]
     name: str
     description: str
     finalized: bool

--- a/tests/instance_test.py
+++ b/tests/instance_test.py
@@ -48,3 +48,5 @@ def test_instance_parameter(api_mock):
 
     with pytest.raises(TypeError):
         inst.parameter["param2"] = "15"
+
+    koi.deinit()


### PR DESCRIPTION
Use multiple RunableInstances to speed up the inference in setups with lots of changing instances